### PR TITLE
Add missing quote in JSON Expressions example

### DIFF
--- a/docs/book/advanced.md
+++ b/docs/book/advanced.md
@@ -100,7 +100,7 @@ As an example:
 $data = [
     'onClick' => new Laminas\Json\Expr(
         'function() {'
-        . 'alert("I am a valid JavaScript callback created by Laminas\\Json");
+        . 'alert("I am a valid JavaScript callback created by Laminas\\Json");'
         . '}'
     ),
     'other' => 'no expression',


### PR DESCRIPTION
Just one `'`